### PR TITLE
fixed broken links to /peering

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ buttons:
       <div class="col-md-6">
         <h1>Peering</h1>
         <p class="lead">We have an open policy; if you can get a link to us, you can peer</p>
-        <p>See our <a href="/peering/">peering policy</a> entry for more info</p>
+        <p>See our <a href="/peering">peering policy</a> entry for more info</p>
       </div>
     </div>
     <div class="row align-items-center">

--- a/tunnelbroker.md
+++ b/tunnelbroker.md
@@ -18,4 +18,4 @@ We can give a prefix from our own address space to you, anywhere from a /64 to a
 
 If you have your own ASN and some public IPv4/IPv6 space we're happy to provide you with
 a tunnel in which to peer with us over for hobby purposes, subject to our standard 
-[peering policy](/peering/).
+[peering policy](/peering).


### PR DESCRIPTION
This fixes #1 by replacing links to `/peering/` with links to `/peering`