### PR TITLE
Fix Telephone Number link

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -6,7 +6,7 @@ title: Contact Us
 # Complaints & Abuse
 
 If you are unsatisfied with our services or wish to file an abuse report you may do it by email, post, or phone.
-Our contact email is [info@as207960.net](mailto:info@as207960.net). Our abuse email is [abuse@as207960.net](mailto:abuse@as207960.net). You may contact us by phone or fax on [+44 29 2010 2455](tel:tel:+442920102455).
+Our contact email is [info@as207960.net](mailto:info@as207960.net). Our abuse email is [abuse@as207960.net](mailto:abuse@as207960.net). You may contact us by phone or fax on [+44 29 2010 2455](tel:+442920102455).
 Our postal address is: 13 Pen-y-lan Terrace, Caerdydd, Cymru, CF23 9EU, UK
 
 If you contact us via post, fax, or email we will make every effort to get a response to you within 24 hours for email and one working week for post and fax.


### PR DESCRIPTION
Fixes the Contact page telephone number link from having two `tel:` URL schemes