### PR TITLE
Fixed geofeeds

### DIFF
--- a/assets/geofeeds.csv
+++ b/assets/geofeeds.csv
@@ -1,9 +1,9 @@
 # AS207960 RFC 8805 GeoFeed file
-45.129.95.0,GB,GB-SCO,Aberdeen,
+45.129.95.0,GB,GB-SCT,Aberdeen,
 45.129.95.1,GB,GB-ENG,London,
 45.129.95.2,GB,GB-ENG,London,
 45.129.95.3,DE,DE-HE,Frankfurt,
-45.129.95.4,GB,GB-SCO,Aberdeen,
+45.129.95.4,GB,GB-SCT,Aberdeen,
 45.129.95.5,GB,GB-ENG,Huddersfield,
 45.129.95.6,,,,
 45.129.95.7,GB,GB-ENG,London,

--- a/assets/geofeeds.csv
+++ b/assets/geofeeds.csv
@@ -24,7 +24,7 @@
 2a0d:1a40:7900:fd00::/56,GB,GB-ENG,,
 2a0d:1a40:79ff::/48,GB,GB-ENG,Huddersfield,
 2a0d:1a40:7901::/48,,,,
-2a0e:1cc1::/64,GB,GB-SCO,Aberdeen,
+2a0e:1cc1::/64,GB,GB-SCT,Aberdeen,
 2a0e:1cc1:0:1::/64,GB,GB-CYM,Caerdydd,
 2a0e:1cc1:0:2::/64,GB,GB-CYM,Caerdydd,
 2a0e:1cc1:0:3::/64,DE,DE-SN,Falkenstein,


### PR DESCRIPTION
# Problem
Geofeed column 2 is per spec to be an ISO-3166-2 country code

GB-SCO does not appear valid country code; while SCO is used for Scotish plates; Scotland's ISO-3166-2 code is defined to be GB-SCT

# Source
- [ISO Country Code Browser](https://www.iso.org/obp/ui#iso:code:3166:GB)
- [Geolocate Much](https://geolocatemuch.com/?resource=45.129.95.0)

